### PR TITLE
Removed unnecessary warning about missing font size

### DIFF
--- a/resize-font
+++ b/resize-font
@@ -101,9 +101,6 @@ sub on_user_command {
       }),
     };
   }
-  else {
-    die "no font size found";
-  }
 
   ()
 }


### PR DESCRIPTION
The else statement removed here triggered on any user command, whether or not it's relevant to font resize.

For example, I would see output `no font size found` in terminal logs for switching tabs using tabbedex. This PR prevents that.
