### PR TITLE
Allow fractional font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ manual page.
 You can also configure the number of steps to take when changing the font size:
 
     URxvt.resize-font.step: 2
+
+And even fractions like 0.2 are supported.

--- a/resize-font
+++ b/resize-font
@@ -122,6 +122,18 @@ sub set_font {
   $self->cmd_parse(sprintf("\33]%d;%s\007", $font->{'code'}, $new));
 }
 
+sub round {
+  return sprintf("%.0f", @_);
+}
+
+sub atleast {
+  my ($min, $val) = @_;
+  if (0 < abs $val && abs $val < $min){
+     return $val / abs($val)
+  }
+  return $val;
+}
+
 sub update_font_size {
   my ($self, $font, $delta) = @_;
   my $regex = qr"(?<=size=)(\d+(?:\.\d+)?)";
@@ -138,8 +150,18 @@ sub update_font_size {
   elsif ($current =~ /^-/) {
     my @font = split(/-/, $current);
     # https://en.wikipedia.org/wiki/X_logical_font_description
-    my $newsize = $font[7]+$delta;
-    $font[7] = $newsize if ($newsize > 0);
+    #Pixel size
+    if ($font[7] gt 0) {
+      $delta = atleast(1, $delta);
+      my $newsize = round($font[7]+$delta);
+      $font[7] = $newsize if ($newsize > 0)
+    }
+    #Point size
+    elsif ($font[8] gt 0) {
+      $delta = atleast(1, $delta*10);
+      my $newsize = round($font[8]+$delta);
+      $font[8] = $newsize if ($newsize > 0)
+    }
     $current = join('-', @font);
   }
   else {

--- a/resize-font
+++ b/resize-font
@@ -124,7 +124,7 @@ sub set_font {
 
 sub update_font_size {
   my ($self, $font, $delta) = @_;
-  my $regex = qr"(?<=size=)(\d+)";
+  my $regex = qr"(?<=size=)(\d+(?:\.\d+)?)";
   my $current = get_font($self, $font->{'name'});
 
   my ($index) = grep { $fixed[$_] eq $current } 0..$#fixed;


### PR DESCRIPTION
With this simple change setting non integer steps works.
Without this having a step of e.g. 0.5 would repeatedly append ".5" to the size.

Works for xft and doesn't break X/XFLD or fixed fonts as far as I tested.